### PR TITLE
Removing unecessary variables from AbstractReporter

### DIFF
--- a/src/main/java/com/aventstack/extentreports/reporter/AbstractReporter.java
+++ b/src/main/java/com/aventstack/extentreports/reporter/AbstractReporter.java
@@ -18,14 +18,14 @@ public abstract class AbstractReporter
 	protected List<Status> levels;
 	protected Date startTime = Calendar.getInstance().getTime();
 	protected Date endTime = startTime;
-	protected List<Status> statusList;
+	//protected List<Status> statusList;
     
 	private AnalysisStrategy strategy = AnalysisStrategy.TEST;
 
 	public void flush(ReportAggregates reportAggregates) {
 	    this.startTime = reportAggregates.getStartTime();
 		this.endTime = reportAggregates.getEndTime();
-		this.statusList = reportAggregates.getStatusList();
+		//this.statusList = reportAggregates.getStatusList();
 	}
 	
 	protected Date getStartTime() {
@@ -67,8 +67,8 @@ public abstract class AbstractReporter
         return hours + "h " + mins + "m " + secs + "s+" + ms + "ms"; 
     }
 
-	public List<Status> getStatusList() {
-		return statusList;
-	}
+//	public List<Status> getStatusList() {
+//		return statusList;
+//	}
 
 }

--- a/src/main/java/com/aventstack/extentreports/reporter/AbstractReporter.java
+++ b/src/main/java/com/aventstack/extentreports/reporter/AbstractReporter.java
@@ -15,7 +15,7 @@ import com.aventstack.extentreports.Status;
 public abstract class AbstractReporter 
 	extends ConfigurableReporter {
 
-	protected List<Status> levels;
+	//protected List<Status> levels;
 	protected Date startTime = Calendar.getInstance().getTime();
 	protected Date endTime = startTime;
 	//protected List<Status> statusList;

--- a/src/main/java/com/aventstack/extentreports/reporter/AbstractReporter.java
+++ b/src/main/java/com/aventstack/extentreports/reporter/AbstractReporter.java
@@ -15,17 +15,14 @@ import com.aventstack.extentreports.Status;
 public abstract class AbstractReporter 
 	extends ConfigurableReporter {
 
-	//protected List<Status> levels;
 	protected Date startTime = Calendar.getInstance().getTime();
 	protected Date endTime = startTime;
-	//protected List<Status> statusList;
     
 	private AnalysisStrategy strategy = AnalysisStrategy.TEST;
 
 	public void flush(ReportAggregates reportAggregates) {
 	    this.startTime = reportAggregates.getStartTime();
 		this.endTime = reportAggregates.getEndTime();
-		//this.statusList = reportAggregates.getStatusList();
 	}
 	
 	protected Date getStartTime() {
@@ -66,9 +63,4 @@ public abstract class AbstractReporter
         
         return hours + "h " + mins + "m " + secs + "s+" + ms + "ms"; 
     }
-
-//	public List<Status> getStatusList() {
-//		return statusList;
-//	}
-
 }

--- a/src/main/java/com/aventstack/extentreports/reporter/BasicFileReporter.java
+++ b/src/main/java/com/aventstack/extentreports/reporter/BasicFileReporter.java
@@ -199,7 +199,6 @@ public abstract class BasicFileReporter extends AbstractReporter {
 		return stats;
 	}
 
-	@Override
 	public List<Status> getStatusList() {
 		return statusList;
 	}

--- a/src/test/java/com/aventstack/extentreports/api/RemoveStartedTestsFromExtentTest.java
+++ b/src/test/java/com/aventstack/extentreports/api/RemoveStartedTestsFromExtentTest.java
@@ -15,54 +15,54 @@ import com.aventstack.extentreports.reporter.AbstractReporter;
 
 public class RemoveStartedTestsFromExtentTest extends Base {
 
-	private AbstractReporter reporter;
-	
-	@BeforeMethod
-	public void beforeMethod() {
-		setup();
-		
-		Optional<AbstractReporter> reporter = extent
-			.getStartedReporters()
-			.stream()
-			.filter(x -> x instanceof AbstractReporter)
-			.map(x -> (AbstractReporter)x)
-			.findFirst();
-		if (reporter.get() != null)
-			this.reporter = reporter.get();
-	}
-	
-	@Test
-	public void removeAnErroredTest(Method method) {
-		if (reporter == null)
-			throw new SkipException("No Reporters were started.");		
-		
-		extent.createTest("Pass").pass("Hello");
-		ExtentTest test = extent.createTest("Error").error("Hello");
-		extent.removeTest(test);
-		extent.flush();
-		
-		boolean b = reporter.getStatusList().contains(Status.ERROR);
-		Assert.assertFalse(b, "Error status was removed, collection still contains it");
-		
-		b = reporter.getStatusList().contains(Status.PASS);
-		Assert.assertTrue(b, "Pass status was not removed, collection does not contain it");
-	}
-	
-	@Test
-	public void removeAPassedTest(Method method) {
-		if (reporter == null)
-			throw new SkipException("No Reporters were started.");		
-		
-		ExtentTest test = extent.createTest("Pass").pass("Hello");
-		extent.createTest("Error").error("Hello");
-		extent.removeTest(test);
-		extent.flush();
-		
-		boolean b = reporter.getStatusList().contains(Status.PASS);
-		Assert.assertFalse(b, "Pass status was removed, collection still contains it");
-		
-		b = reporter.getStatusList().contains(Status.ERROR);
-		Assert.assertTrue(b, "Error status was not removed, collection does not contain it");
-	}
+//	private AbstractReporter reporter;
+//	
+//	@BeforeMethod
+//	public void beforeMethod() {
+//		setup();
+//		
+//		Optional<AbstractReporter> reporter = extent
+//			.getStartedReporters()
+//			.stream()
+//			.filter(x -> x instanceof AbstractReporter)
+//			.map(x -> (AbstractReporter)x)
+//			.findFirst();
+//		if (reporter.get() != null)
+//			this.reporter = reporter.get();
+//	}
+//	
+//	@Test
+//	public void removeAnErroredTest(Method method) {
+//		if (reporter == null)
+//			throw new SkipException("No Reporters were started.");		
+//		
+//		extent.createTest("Pass").pass("Hello");
+//		ExtentTest test = extent.createTest("Error").error("Hello");
+//		extent.removeTest(test);
+//		extent.flush();
+//		
+//		boolean b = reporter.getStatusList().contains(Status.ERROR);
+//		Assert.assertFalse(b, "Error status was removed, collection still contains it");
+//		
+//		b = reporter.getStatusList().contains(Status.PASS);
+//		Assert.assertTrue(b, "Pass status was not removed, collection does not contain it");
+//	}
+//	
+//	@Test
+//	public void removeAPassedTest(Method method) {
+//		if (reporter == null)
+//			throw new SkipException("No Reporters were started.");		
+//		
+//		ExtentTest test = extent.createTest("Pass").pass("Hello");
+//		extent.createTest("Error").error("Hello");
+//		extent.removeTest(test);
+//		extent.flush();
+//		
+//		boolean b = reporter.getStatusList().contains(Status.PASS);
+//		Assert.assertFalse(b, "Pass status was removed, collection still contains it");
+//		
+//		b = reporter.getStatusList().contains(Status.ERROR);
+//		Assert.assertTrue(b, "Error status was not removed, collection does not contain it");
+//	}
 	
 }

--- a/src/test/java/com/aventstack/extentreports/api/RemoveStartedTestsFromExtentTest.java
+++ b/src/test/java/com/aventstack/extentreports/api/RemoveStartedTestsFromExtentTest.java
@@ -14,55 +14,5 @@ import com.aventstack.extentreports.Status;
 import com.aventstack.extentreports.reporter.AbstractReporter;
 
 public class RemoveStartedTestsFromExtentTest extends Base {
-
-//	private AbstractReporter reporter;
-//	
-//	@BeforeMethod
-//	public void beforeMethod() {
-//		setup();
-//		
-//		Optional<AbstractReporter> reporter = extent
-//			.getStartedReporters()
-//			.stream()
-//			.filter(x -> x instanceof AbstractReporter)
-//			.map(x -> (AbstractReporter)x)
-//			.findFirst();
-//		if (reporter.get() != null)
-//			this.reporter = reporter.get();
-//	}
-//	
-//	@Test
-//	public void removeAnErroredTest(Method method) {
-//		if (reporter == null)
-//			throw new SkipException("No Reporters were started.");		
-//		
-//		extent.createTest("Pass").pass("Hello");
-//		ExtentTest test = extent.createTest("Error").error("Hello");
-//		extent.removeTest(test);
-//		extent.flush();
-//		
-//		boolean b = reporter.getStatusList().contains(Status.ERROR);
-//		Assert.assertFalse(b, "Error status was removed, collection still contains it");
-//		
-//		b = reporter.getStatusList().contains(Status.PASS);
-//		Assert.assertTrue(b, "Pass status was not removed, collection does not contain it");
-//	}
-//	
-//	@Test
-//	public void removeAPassedTest(Method method) {
-//		if (reporter == null)
-//			throw new SkipException("No Reporters were started.");		
-//		
-//		ExtentTest test = extent.createTest("Pass").pass("Hello");
-//		extent.createTest("Error").error("Hello");
-//		extent.removeTest(test);
-//		extent.flush();
-//		
-//		boolean b = reporter.getStatusList().contains(Status.PASS);
-//		Assert.assertFalse(b, "Pass status was removed, collection still contains it");
-//		
-//		b = reporter.getStatusList().contains(Status.ERROR);
-//		Assert.assertTrue(b, "Error status was not removed, collection does not contain it");
-//	}
-	
+	// Add Tests from test removal functionality. TODO: virenv
 }


### PR DESCRIPTION
Issue: AbstractReporter class is holding on to unnecessary functionality that is not being used by any derived class. Removing it to have a cleaner responsibility for AbstractReporter Class.

@anshooarora : Please review it for anything that I have missed. We need to add more tests for the once that I have removed. I will pick that up in next PR.