### PR TITLE
Fix concurrentModification exception

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ hs_err_pid*
 target/
 test-output/
 *.iml
+
+# IntelliJ #
+*.idea

--- a/src/main/java/com/aventstack/extentreports/ExtentObservable.java
+++ b/src/main/java/com/aventstack/extentreports/ExtentObservable.java
@@ -7,8 +7,6 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.EnumMap;
 import java.util.List;
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReentrantLock;
 
 import com.aventstack.extentreports.concurrent.ReadWriteList;
 import com.aventstack.extentreports.concurrent.ReadWriteMap;
@@ -173,7 +171,6 @@ abstract class ExtentObservable
 	 */
 	private final ReadWriteMap<Status, Boolean> statusMap = new ReadWriteMap<>(new EnumMap<>(Status.class));
 
-	private final Lock mutex = new ReentrantLock();
 	
     protected ExtentObservable() { }
     

--- a/src/main/java/com/aventstack/extentreports/ExtentObservable.java
+++ b/src/main/java/com/aventstack/extentreports/ExtentObservable.java
@@ -307,7 +307,7 @@ abstract class ExtentObservable
 		list.stream()
 				.map(Test::getStatus)
 				.distinct()
-				.map(x -> statusMap.put(x, false));
+				.forEach(x -> statusMap.put(x, false));
 
 	}
     

--- a/src/main/java/com/aventstack/extentreports/ReportStatusStats.java
+++ b/src/main/java/com/aventstack/extentreports/ReportStatusStats.java
@@ -2,6 +2,7 @@ package com.aventstack.extentreports;
 
 import java.util.List;
 
+import com.aventstack.extentreports.concurrent.ReadWriteList;
 import com.aventstack.extentreports.exceptions.InvalidAnalysisStrategyException;
 import com.aventstack.extentreports.gherkin.model.Scenario;
 import com.aventstack.extentreports.model.Test;
@@ -13,10 +14,10 @@ import com.aventstack.extentreports.model.Test;
  */
 public class ReportStatusStats {
     
-    private List<Test> testList;
-    private AnalysisStrategy strategy = AnalysisStrategy.TEST;
+    private ReadWriteList<Test> testList;
+    private AnalysisStrategy strategy;
     
-    private int parentPass = 0; 
+    private int parentPass = 0;
     private int parentFail = 0;
     private int parentFatal = 0;
     private int parentError = 0;
@@ -50,7 +51,7 @@ public class ReportStatusStats {
 
     public void refresh(List<Test> testList) {
         reset();
-        this.testList = testList;
+        this.testList = new ReadWriteList<>(testList);
         refreshStats();
     }
 

--- a/src/main/java/com/aventstack/extentreports/concurrent/ReadWriteList.java
+++ b/src/main/java/com/aventstack/extentreports/concurrent/ReadWriteList.java
@@ -1,0 +1,103 @@
+package com.aventstack.extentreports.concurrent;
+
+import com.aventstack.extentreports.utils.CollectionUtils;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.function.Consumer;
+
+/**
+ * ReadWriteList.java
+ * This class demonstrates how to use ReadWriteLock to add concurrency
+ * features to a non-threadsafe collection
+ *
+ * @author www.codejava.net
+ */
+public class ReadWriteList<E> {
+	private final List<E> list;
+	private final ReadWriteLock rwLock;
+
+	public List<E> getList() {
+		return list;
+	}
+
+	public ReadWriteList(List<E> list) {
+		this.list = Collections.synchronizedList(list);
+		this.rwLock = new ReentrantReadWriteLock();
+	}
+
+	public ReadWriteList() {
+		rwLock = new ReentrantReadWriteLock();
+		list = Collections.synchronizedList(new ArrayList<>());
+	}
+
+	public void add(E element) {
+		rwLock.writeLock().lock();
+		try {
+			list.add(element);
+		} finally {
+			rwLock.writeLock().unlock();
+		}
+	}
+
+	public E get(int index) {
+		rwLock.readLock().lock();
+		try {
+			return list.get(index);
+		} finally {
+			rwLock.readLock().unlock();
+		}
+	}
+
+	public void clear() {
+		rwLock.readLock().lock();
+		try {
+			list.clear();
+		} finally {
+			rwLock.readLock().unlock();
+		}
+	}
+
+	public E remove(int index) {
+		rwLock.writeLock().lock();
+		try {
+			return list.remove(index);
+		} finally {
+			rwLock.writeLock().unlock();
+		}
+	}
+
+	public boolean isEmpty() {
+		rwLock.readLock().lock();
+		try {
+			return CollectionUtils.isEmpty(list);
+		} finally {
+			rwLock.readLock().unlock();
+		}
+	}
+
+	public boolean isNotEmpty() {
+		return !isEmpty();
+	}
+
+	public int size() {
+		rwLock.readLock().lock();
+		try {
+			return list.size();
+		} finally {
+			rwLock.readLock().unlock();
+		}
+	}
+
+	public void forEach(Consumer<? super E> action){
+		rwLock.writeLock().lock();
+		try {
+			list.forEach(action);
+		}finally {
+			rwLock.writeLock().unlock();
+		}
+	}
+}

--- a/src/main/java/com/aventstack/extentreports/concurrent/ReadWriteList.java
+++ b/src/main/java/com/aventstack/extentreports/concurrent/ReadWriteList.java
@@ -1,5 +1,7 @@
 package com.aventstack.extentreports.concurrent;
 
+import com.aventstack.extentreports.Status;
+import com.aventstack.extentreports.model.Test;
 import com.aventstack.extentreports.utils.CollectionUtils;
 
 import java.util.ArrayList;
@@ -17,8 +19,8 @@ import java.util.function.Consumer;
  * @author www.codejava.net
  */
 public class ReadWriteList<E> {
-	private final List<E> list;
-	private final ReadWriteLock rwLock;
+	protected final List<E> list;
+	protected final ReadWriteLock rwLock;
 
 	public List<E> getList() {
 		return list;
@@ -91,6 +93,9 @@ public class ReadWriteList<E> {
 			rwLock.readLock().unlock();
 		}
 	}
+
+	public void streamWithLock(final ReadWriteMap<Status, Boolean> statusMap) {}
+
 
 	public void forEach(Consumer<? super E> action){
 		rwLock.writeLock().lock();

--- a/src/main/java/com/aventstack/extentreports/concurrent/ReadWriteMap.java
+++ b/src/main/java/com/aventstack/extentreports/concurrent/ReadWriteMap.java
@@ -1,0 +1,70 @@
+package com.aventstack.extentreports.concurrent;
+
+
+import java.util.Map;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.function.BiConsumer;
+
+/**
+ * ReadWriteList.java
+ * This class demonstrates how to use ReadWriteLock to add concurrency
+ * features to a non-threadsafe collection
+ *
+ * @author www.codejava.net
+ */
+public class ReadWriteMap<K, V> {
+	private final Map<K, V> map;
+	private final ReadWriteLock rwLock;
+
+	public ReadWriteMap(Map<K, V> map) {
+		this.map = map;
+		this.rwLock = new ReentrantReadWriteLock();
+	}
+
+	/**
+	 * Put operation with write lock
+	 */
+	public V put(K key, V value) {
+		rwLock.writeLock().lock();
+		try {
+			return map.put(key, value);
+		} finally {
+			rwLock.writeLock().unlock();
+		}
+	}
+
+	/**
+	 * Remove all elements from map
+	 */
+	public void clear(){
+		rwLock.writeLock().lock();
+		try {
+			map.clear();
+		} finally {
+			rwLock.writeLock().unlock();
+		}
+	}
+
+	/**
+	 * Get value from ma with lock read
+	 */
+	public V get(K key) {
+		rwLock.readLock().lock();
+		try {
+			return map.get(key);
+		} finally {
+			rwLock.readLock().unlock();
+		}
+	}
+
+	public void forEach(BiConsumer<? super K, ? super V> action){
+		rwLock.writeLock().lock();
+		try {
+			map.forEach(action);
+		}finally {
+			rwLock.writeLock().unlock();
+		}
+	}
+
+}

--- a/src/main/java/com/aventstack/extentreports/concurrent/ReadWriteTestList.java
+++ b/src/main/java/com/aventstack/extentreports/concurrent/ReadWriteTestList.java
@@ -1,0 +1,21 @@
+package com.aventstack.extentreports.concurrent;
+
+import com.aventstack.extentreports.Status;
+import com.aventstack.extentreports.model.Test;
+
+public class ReadWriteTestList extends ReadWriteList<Test> {
+
+	@Override
+	public void streamWithLock(final ReadWriteMap<Status, Boolean> statusMap) {
+		rwLock.writeLock().lock();
+		try {
+			list.stream()
+					.map(Test::getStatus)
+					.distinct()
+					.forEach(x -> statusMap.put(x, false));
+		} finally {
+			rwLock.writeLock().unlock();
+		}
+	}
+
+}

--- a/src/main/java/com/aventstack/extentreports/model/AbstractStructure.java
+++ b/src/main/java/com/aventstack/extentreports/model/AbstractStructure.java
@@ -1,79 +1,47 @@
 package com.aventstack.extentreports.model;
 
+import com.aventstack.extentreports.concurrent.ReadWriteList;
+
 import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
 
 public class AbstractStructure<T> implements Serializable {
 
-    private static final long serialVersionUID = -2630417398255980331L;
-    
-    private transient List<T> list;
+	private static final long serialVersionUID = -2630417398255980331L;
+	private final ReadWriteList<T> readWriteList;
 
-    AbstractStructure() {
-        list = Collections.synchronizedList(new ArrayList<>());
-    }
-    
-    public void add(T t) {
-        list.add(t);
-    }
 
-    public T get(int x) {
-        return list.get(x);
-    }
-    
-    public T getFirst() {
-        return list.isEmpty() ? null : list.get(0);
-    }
-    
-    public T getLast() {
-        return list.isEmpty() ? null : list.get(list.size()-1);
-    }
+	AbstractStructure() {
+		readWriteList = new ReadWriteList<>();
+	}
 
-    public List<T> getAll() {
-        return list;
-    }
-    
-    public int size() {
-        if (list == null)
-            return 0;
-        return list.size();
-    }
-    
-    public boolean isEmpty() {
-    	return size() == 0;
-    }
+	public void add(T t) {
+		readWriteList.add(t);
+	}
 
-    public TIterator getIterator() { return new TIterator(); }
+	public T get(int x) {
+		return readWriteList.get(x);
+	}
 
-    private class TIterator implements Iterator<T> {
-        private int index;
+	public T getFirst() {
+		return readWriteList.get(0);
+	}
 
-        TIterator() {
-            index = 0;
-        }
+	public T getLast() {
+		return readWriteList.get(readWriteList.size() - 1);
+	}
 
-        @Override
-        public boolean hasNext() {
-            return list != null && list.size() >= index + 1;
-        }
+	public List<T> getAll() {
+		return readWriteList.getList();
+	}
 
-        @Override
-        public T next() {
-            if (hasNext()) {
-                return list.get(index++);
-            }
+	public boolean isEmpty() {
+		return readWriteList.isEmpty();
+	}
 
-            throw new NoSuchElementException();
-        }
-
-        @Override
-        public void remove() {
-            list.remove(index);
-        }
-    }
-    
+	public int size(){
+		return readWriteList.size();
+	}
 }

--- a/src/main/java/com/aventstack/extentreports/model/AbstractStructure.java
+++ b/src/main/java/com/aventstack/extentreports/model/AbstractStructure.java
@@ -33,9 +33,16 @@ public class AbstractStructure<T> implements Serializable {
 		return readWriteList.get(readWriteList.size() - 1);
 	}
 
+	// TODO not perfectly because we want always to work with read write mechanism - but it is so much change
+	// getAll should rturn ReadWriteList ...
 	public List<T> getAll() {
 		return readWriteList.getList();
 	}
+
+	public ReadWriteList<T> getReadWriteList() {
+		return readWriteList;
+	}
+
 
 	public boolean isEmpty() {
 		return readWriteList.isEmpty();

--- a/src/main/java/com/aventstack/extentreports/model/Test.java
+++ b/src/main/java/com/aventstack/extentreports/model/Test.java
@@ -290,7 +290,8 @@ public class Test
         test.getLogContext().getAll().forEach(x -> updateStatus(x.getStatus()));
 
         if (test.hasChildren()) {
-            test.getNodeContext().getAll().forEach(this::updateTestStatusRecursive);
+            final List<Test>nodes = new ArrayList<>(test.getNodeContext().getAll());
+            nodes.forEach(this::updateTestStatusRecursive);
         }
         
         // if not all children are marked SKIP, then:
@@ -313,6 +314,7 @@ public class Test
     }
     
     private void endChildrenRecursive(Test test) {
+
         test.getNodeContext().getAll().forEach(Test::end);
     }
 

--- a/src/main/java/com/aventstack/extentreports/model/Test.java
+++ b/src/main/java/com/aventstack/extentreports/model/Test.java
@@ -287,7 +287,7 @@ public class Test
     }
 
     private synchronized void updateTestStatusRecursive(Test test) {
-        test.getLogContext().getAll().forEach(x -> updateStatus(x.getStatus()));
+        test.getLogContext().getReadWriteList().forEach(x -> updateStatus(x.getStatus()));
 
         if (test.hasChildren()) {
             final List<Test>nodes = new ArrayList<>(test.getNodeContext().getAll());

--- a/src/main/java/com/aventstack/extentreports/utils/CollectionUtils.java
+++ b/src/main/java/com/aventstack/extentreports/utils/CollectionUtils.java
@@ -1,0 +1,20 @@
+package com.aventstack.extentreports.utils;
+
+import java.util.Collection;
+
+public class CollectionUtils {
+
+	private CollectionUtils(){}
+
+	public static boolean isNull(Collection<?> col) {
+		return col == null;
+	}
+
+	public static boolean isEmpty(Collection<?> col) {
+		return isNull(col) || col.isEmpty();
+	}
+
+	public static boolean isNotEmpty(Collection<?> col) {
+		return !isEmpty(col);
+	}
+}

--- a/src/test/java/com/aventstack/extentreports/testng/components/TestNodes.java
+++ b/src/test/java/com/aventstack/extentreports/testng/components/TestNodes.java
@@ -1,0 +1,110 @@
+package com.aventstack.extentreports.testng.components;
+import com.aventstack.extentreports.ExtentReports;
+import com.aventstack.extentreports.ExtentTest;
+import com.aventstack.extentreports.Status;
+import com.aventstack.extentreports.common.ExtentManager;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+public class TestNodes {
+	private static final ExtentReports extent = ExtentManager.createInstance();
+	private static final ExtentTest parent = extent.createTest("Test");
+
+
+	@Test(dataProvider = "avoidConcurrentModifException")
+	public void testConcurrentModifException(final int msg) {
+		final ExtentTest child = parent.createNode("node");
+		child.log(Status.INFO, "something");
+		if (msg % 2 == 0) {
+			child.pass("Tet passed");
+		} else {
+			child.fail("Parent failed");
+		}
+	}
+
+	@DataProvider(name = "avoidConcurrentModifException", parallel = true)
+	private Object[][] avoidConcurrentModifException() {
+		return new Object[][]{
+				{1},
+				{2},
+				{3},
+				{4},
+				{5},
+				{6},
+				{7},
+				{8},
+				{9},
+				{10},
+				{11},
+				{12},
+				{13},
+				{14},
+				{15},
+				{16},
+				{17},
+				{18},
+				{19},
+				{20},
+				{21},
+				{22},
+				{23},
+				{24},
+				{25},
+				{26},
+				{27},
+				{28},
+				{29},
+				{30},
+				{31},
+				{32},
+				{33},
+				{34},
+				{35},
+				{36},
+				{37},
+				{38},
+				{39},
+				{40},
+				{1},
+				{2},
+				{3},
+				{4},
+				{5},
+				{6},
+				{7},
+				{8},
+				{9},
+				{10},
+				{11},
+				{12},
+				{13},
+				{14},
+				{15},
+				{16},
+				{17},
+				{18},
+				{19},
+				{20},
+				{21},
+				{22},
+				{23},
+				{24},
+				{25},
+				{26},
+				{27},
+				{28},
+				{29},
+				{30},
+				{31},
+				{32},
+				{33},
+				{34},
+				{35},
+				{36},
+				{37},
+				{38},
+				{39},
+				{40},
+		};
+	}
+}

--- a/src/test/java/com/aventstack/extentreports/testng/components/TestWithMultipleDataset.java
+++ b/src/test/java/com/aventstack/extentreports/testng/components/TestWithMultipleDataset.java
@@ -1,18 +1,31 @@
 package com.aventstack.extentreports.testng.components;
+
 import com.aventstack.extentreports.ExtentReports;
 import com.aventstack.extentreports.ExtentTest;
 import com.aventstack.extentreports.Status;
 import com.aventstack.extentreports.common.ExtentManager;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
-public class TestNodes {
-	private static final ExtentReports extent = ExtentManager.createInstance();
-	private static final ExtentTest parent = extent.createTest("Test");
+public class TestWithMultipleDataset {
+	private ExtentReports extent;
+	private ExtentTest parent;
 
+	@BeforeClass
+	public void beforeClass() {
+		extent = ExtentManager.createInstance();
+		parent = extent.createTest("Test");
+	}
 
-	@Test(dataProvider = "avoidConcurrentModifException")
-	public void testConcurrentModifException(final int msg) {
+	@AfterClass
+	public void afterClass() {
+		ExtentManager.getInstance().flush();
+	}
+
+	@Test(dataProvider = "avoidConcurrentModificationException", enabled = false)
+	public void testConcurrentModificationException(final int msg) {
 		final ExtentTest child = parent.createNode("node");
 		child.log(Status.INFO, "something");
 		if (msg % 2 == 0) {
@@ -22,8 +35,8 @@ public class TestNodes {
 		}
 	}
 
-	@DataProvider(name = "avoidConcurrentModifException", parallel = true)
-	private Object[][] avoidConcurrentModifException() {
+	@DataProvider(name = "avoidConcurrentModificationException", parallel = true)
+	private Object[][] avoidConcurrentModificationException() {
 		return new Object[][]{
 				{1},
 				{2},
@@ -65,46 +78,16 @@ public class TestNodes {
 				{38},
 				{39},
 				{40},
-				{1},
-				{2},
-				{3},
-				{4},
-				{5},
-				{6},
-				{7},
-				{8},
-				{9},
-				{10},
-				{11},
-				{12},
-				{13},
-				{14},
-				{15},
-				{16},
-				{17},
-				{18},
-				{19},
-				{20},
-				{21},
-				{22},
-				{23},
-				{24},
-				{25},
-				{26},
-				{27},
-				{28},
-				{29},
-				{30},
-				{31},
-				{32},
-				{33},
-				{34},
-				{35},
-				{36},
-				{37},
-				{38},
-				{39},
-				{40},
+				{41},
+				{42},
+				{43},
+				{44},
+				{45},
+				{46},
+				{47},
+				{48},
+				{49},
+				{50}
 		};
 	}
 }

--- a/src/test/resources/com/aventstack/extentreports/testng/parallel/parallel-dataset.xml
+++ b/src/test/resources/com/aventstack/extentreports/testng/parallel/parallel-dataset.xml
@@ -1,0 +1,8 @@
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd">
+<suite name="ExtentTestMultipleDataset" parallel="methods" thread-count="50">
+    <test name="TestDatasetParallel">
+        <classes>
+            <class name="com.aventstack.extentreports.testng.components.TestWithMultipleDataset" />
+        </classes>
+    </test>
+</suite>


### PR DESCRIPTION
In case of multiple test childs for test parent sometimes Concurrent modification exception has occurred

Fix was used with read and write lock for list and map. 
Also in case of  working with child list its list is copied.
