### PR TITLE
Removing the usage of StatusMap in the ExtentObservable class

### DIFF
--- a/src/main/java/com/aventstack/extentreports/ExtentObservable.java
+++ b/src/main/java/com/aventstack/extentreports/ExtentObservable.java
@@ -4,13 +4,9 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
-import java.util.EnumMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
-import java.util.function.Consumer;
-import java.util.stream.Collectors;
 
 import com.aventstack.extentreports.model.Author;
 import com.aventstack.extentreports.model.Category;
@@ -136,7 +132,7 @@ abstract class ExtentObservable
 	private ReportStatusStats stats = new ReportStatusStats(strategy);
 	
 	/**
-	 * A Set of status tests are marked with
+	 * A unique collection of statuses tests are marked with
 	 * 
 	 * <p>
 	 * Consider a report having 10 tests:

--- a/src/main/java/com/aventstack/extentreports/ExtentObservable.java
+++ b/src/main/java/com/aventstack/extentreports/ExtentObservable.java
@@ -5,8 +5,10 @@ import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.EnumMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
@@ -134,7 +136,7 @@ abstract class ExtentObservable
 	private ReportStatusStats stats = new ReportStatusStats(strategy);
 	
 	/**
-	 * A unique list of status tests are marked with
+	 * A Set of status tests are marked with
 	 * 
 	 * <p>
 	 * Consider a report having 10 tests:
@@ -161,7 +163,7 @@ abstract class ExtentObservable
 	 * <li>FAIL</li>
 	 * </ol>
 	 */
-	private List<Status> statusList = new ArrayList<>();
+	private Set<Status> statusSet = new HashSet<Status>();
 	
     protected ExtentObservable() { }
     
@@ -265,7 +267,7 @@ abstract class ExtentObservable
      * Refresh and notify all reports of distinct status assigned to tests
      */
     private synchronized void refreshStatusList() {
-    	statusList.clear();
+    	statusSet.clear();
     	refreshStatusList(testList);
     }
     
@@ -277,19 +279,8 @@ abstract class ExtentObservable
     private synchronized void refreshStatusList(List<Test> list) {
     	if (list == null || list.isEmpty())
     		return;
-    	
-    	// It is not necessary to go through the stream support of 
-    	// Java 8 here. This brings in a hard binding with Java version.
-    	// As we have used streams all across, this should be fine.
-    	list.stream().forEach(new Consumer<Test>() {
-    		@Override
-    		public void accept(Test t) {
-    			if(!statusList.contains((Object) t)){
-    				statusList.add(t.getStatus());
-    				}
-    			}
-    		});
-    	
+
+    	list.forEach(x -> statusSet.add(x.getStatus()));   	
     	list.forEach(x -> refreshStatusList(x.getNodeContext().getAll()));
     }
     
@@ -536,7 +527,7 @@ abstract class ExtentObservable
     			.setDeviceContext(deviceContext)
     			.setExceptionContext(exceptionContextBuilder)
     			.setReportStatusStats(stats)
-    			.setStatusList(statusList)
+    			.setStatusCollection(statusSet)
     			.setSystemAttributeContext(systemAttributeContext)
     			.setTestList(testList)
     			.setTestRunnerLogs(testRunnerLogs)

--- a/src/main/java/com/aventstack/extentreports/ReportAggregates.java
+++ b/src/main/java/com/aventstack/extentreports/ReportAggregates.java
@@ -3,7 +3,6 @@ package com.aventstack.extentreports;
 import java.util.Collection;
 import java.util.Date;
 import java.util.List;
-import java.util.Set;
 
 import com.aventstack.extentreports.model.Author;
 import com.aventstack.extentreports.model.Category;

--- a/src/main/java/com/aventstack/extentreports/ReportAggregates.java
+++ b/src/main/java/com/aventstack/extentreports/ReportAggregates.java
@@ -1,7 +1,9 @@
 package com.aventstack.extentreports;
 
+import java.util.Collection;
 import java.util.Date;
 import java.util.List;
+import java.util.Set;
 
 import com.aventstack.extentreports.model.Author;
 import com.aventstack.extentreports.model.Category;
@@ -22,7 +24,7 @@ public class ReportAggregates {
 	private ExceptionTestContextImpl exceptionContext;
 	private SystemAttributeContext systemAttributeContext;
 	private ReportStatusStats reportStatusStats;
-	private List<Status> statusList;
+	private Collection<Status> statusCollection;
 	private Date startTime;
     private Date endTime;
     
@@ -43,7 +45,7 @@ public class ReportAggregates {
     }
 
     public Status getStatus() {
-		return Status.getHighestStatus(getStatusList());
+		return Status.getHighestStatus(getStatusCollection());
 	}
 	
 	public List<Test> getTestList() {
@@ -110,12 +112,12 @@ public class ReportAggregates {
         this.reportStatusStats = reportStatusStats;
     }
 
-    public List<Status> getStatusList() {
-        return statusList;
+    public Collection<Status> getStatusCollection() {
+        return statusCollection;
     }
 
-    public void setStatusList(List<Status> statusList) {
-        this.statusList = statusList;
+    public void setStatusCollection(Collection<Status> statusCollection) {
+        this.statusCollection = statusCollection;
     }
 	
 }

--- a/src/main/java/com/aventstack/extentreports/ReportAggregatesBuilder.java
+++ b/src/main/java/com/aventstack/extentreports/ReportAggregatesBuilder.java
@@ -1,5 +1,6 @@
 package com.aventstack.extentreports;
 
+import java.util.Collection;
 import java.util.Date;
 import java.util.List;
 
@@ -22,7 +23,7 @@ public class ReportAggregatesBuilder {
 	private ExceptionTestContextImpl exceptionContext;
 	private SystemAttributeContext systemAttributeContext;
 	private ReportStatusStats reportStatusStats;
-	private List<Status> statusList;
+	private Collection<Status> statusCollection;
 	private Date startTime;
 	private Date endTime;
 	
@@ -36,7 +37,7 @@ public class ReportAggregatesBuilder {
 	    aggregates.setExceptionContext(exceptionContext);
 	    aggregates.setSystemAttributeContext(systemAttributeContext);
 	    aggregates.setReportStatusStats(reportStatusStats);
-	    aggregates.setStatusList(statusList);
+	    aggregates.setStatusCollection(statusCollection);
 	    aggregates.setStartTime(startTime);
 	    aggregates.setEndTime(endTime);
 		return aggregates;
@@ -82,8 +83,8 @@ public class ReportAggregatesBuilder {
 		return this;
 	}
 
-	public ReportAggregatesBuilder setStatusList(List<Status> statusList) {
-		this.statusList = statusList;
+	public ReportAggregatesBuilder setStatusCollection(Collection<Status> statusCollection) {
+		this.statusCollection = statusCollection;
 		return this;
 	}
 

--- a/src/main/java/com/aventstack/extentreports/Status.java
+++ b/src/main/java/com/aventstack/extentreports/Status.java
@@ -2,6 +2,7 @@ package com.aventstack.extentreports;
 
 import java.io.Serializable;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 
 /**
@@ -48,12 +49,12 @@ public enum Status implements Serializable {
         return statusHierarchy;
     }
     
-    public static Status getHighestStatus(List<Status> statusList) {
+    public static Status getHighestStatus(Collection<Status> statusCollection) {
     	Status highestStatus = Status.PASS;
-    	if (statusList == null || statusList.isEmpty()) {
+    	if (statusCollection == null || statusCollection.isEmpty()) {
     		return highestStatus;
     	}
-    	for (Status status : statusList) {
+    	for (Status status : statusCollection) {
     		highestStatus = Status.getStatusHierarchy().indexOf(status) < Status.getStatusHierarchy().indexOf(highestStatus) 
     				? status
 					: highestStatus;

--- a/src/main/java/com/aventstack/extentreports/reporter/BasicFileReporter.java
+++ b/src/main/java/com/aventstack/extentreports/reporter/BasicFileReporter.java
@@ -288,7 +288,7 @@ public abstract class BasicFileReporter extends AbstractReporter {
 	}
 
 	public boolean containsStatus(Status status) {
-		return getStatusList() != null && !getStatusList().isEmpty() && getStatusList().contains(status);
+		return getStatusList() != null && getStatusList().contains(status);
 	}
 
 	protected void processTemplate(Template template, File outputFile) throws TemplateException, IOException {

--- a/src/main/java/com/aventstack/extentreports/reporter/BasicFileReporter.java
+++ b/src/main/java/com/aventstack/extentreports/reporter/BasicFileReporter.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -72,7 +73,7 @@ public abstract class BasicFileReporter extends AbstractReporter {
 	private TestAttributeTestContextProvider<Device> deviceContext;
 	private SystemAttributeContext systemAttributeContext;
 	private ReportStatusStats stats;
-	private List<Status> statusList;
+	private Collection<Status> statusCollection;
 
 	protected BasicFileReporter(String path) {
 		this.filePath = path;
@@ -164,7 +165,7 @@ public abstract class BasicFileReporter extends AbstractReporter {
 		this.systemAttributeContext = reportAggregates.getSystemAttributeContext();
 		this.testList = reportAggregates.getTestList();
 		this.testRunnerLogs = reportAggregates.getTestRunnerLogs();
-		this.statusList = reportAggregates.getStatusList();
+		this.statusCollection = reportAggregates.getStatusCollection();
 	}
 
 	public List<Test> getTestList() {
@@ -199,8 +200,8 @@ public abstract class BasicFileReporter extends AbstractReporter {
 		return stats;
 	}
 
-	public List<Status> getStatusList() {
-		return statusList;
+	public Collection<Status> getStatusCollection() {
+		return statusCollection;
 	}
 
 	@Override
@@ -288,7 +289,7 @@ public abstract class BasicFileReporter extends AbstractReporter {
 	}
 
 	public boolean containsStatus(Status status) {
-		return getStatusList() != null && getStatusList().contains(status);
+		return getStatusCollection() != null && getStatusCollection().contains(status);
 	}
 
 	protected void processTemplate(Template template, File outputFile) throws TemplateException, IOException {


### PR DESCRIPTION
Fixes: This removes the usage of statusMap class in the ExtentObservable class. statusMap was used to store the Status in ordered form. This seems to be a task that we can do while we need to use the statusList instead or preemptively calculating the statusMap every time.

PR also includes some minor changes in logic/code usage.