### PR TITLE
Fixing concurrent modification exception when ExtentTest.addlog is called.

### DIFF
--- a/src/main/java/com/aventstack/extentreports/ExtentObservable.java
+++ b/src/main/java/com/aventstack/extentreports/ExtentObservable.java
@@ -594,8 +594,21 @@ abstract class ExtentObservable
      * @return a {@link ReportStatusStats} object
      */
     protected ReportStatusStats getStats() {
-    	flush();
+    	generateRecentStatus();
     	return stats;
     }
     
+    /**
+     * Calculates the current status of the report and
+     * updates the internal status. After using this we
+     * 
+     * Note: Internal methods to get status like
+     * - ExtentTest.getStatus 
+     * - ExtentReport.getStatus
+     * call this method to calculate the most recent status
+     * before returning the status.
+     */
+    public void generateRecentStatus() {
+    	collectRunInfo();
+    }
 }

--- a/src/main/java/com/aventstack/extentreports/ExtentObservable.java
+++ b/src/main/java/com/aventstack/extentreports/ExtentObservable.java
@@ -296,7 +296,6 @@ abstract class ExtentObservable
      * @param log {@link Log}
      */
     synchronized void addLog(Test test, Log log) {
-        //collectRunInfo();
         reporterList.forEach(x -> x.onLogAdded(test, log));
     }
     

--- a/src/main/java/com/aventstack/extentreports/ExtentObservable.java
+++ b/src/main/java/com/aventstack/extentreports/ExtentObservable.java
@@ -414,7 +414,7 @@ abstract class ExtentObservable
      * </ul>
      */
     protected synchronized void flush() {    	
-        collectRunInfo();
+    	generateRecentStatus();
         notifyReporters();
     }
     
@@ -423,7 +423,7 @@ abstract class ExtentObservable
      * Exception, Nodes. This also ends and updates all internal test information and 
      * refreshes {@link ReportStatusStats} and the distinct list of {@link Status}
      */
-    private synchronized void collectRunInfo() {
+    public synchronized void generateRecentStatus() {
         if (testList == null || testList.isEmpty())
             return;
         
@@ -596,19 +596,5 @@ abstract class ExtentObservable
     protected ReportStatusStats getStats() {
     	generateRecentStatus();
     	return stats;
-    }
-    
-    /**
-     * Calculates the current status of the report and
-     * updates the internal status. After using this we
-     * 
-     * Note: Internal methods to get status like
-     * - ExtentTest.getStatus 
-     * - ExtentReport.getStatus
-     * call this method to calculate the most recent status
-     * before returning the status.
-     */
-    public void generateRecentStatus() {
-    	collectRunInfo();
     }
 }

--- a/src/main/java/com/aventstack/extentreports/ExtentObservable.java
+++ b/src/main/java/com/aventstack/extentreports/ExtentObservable.java
@@ -296,7 +296,7 @@ abstract class ExtentObservable
      * @param log {@link Log}
      */
     synchronized void addLog(Test test, Log log) {
-        collectRunInfo();
+        //collectRunInfo();
         reporterList.forEach(x -> x.onLogAdded(test, log));
     }
     

--- a/src/main/java/com/aventstack/extentreports/ExtentObservable.java
+++ b/src/main/java/com/aventstack/extentreports/ExtentObservable.java
@@ -4,13 +4,9 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
-import java.util.EnumMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
-import java.util.function.Consumer;
-import java.util.stream.Collectors;
 
 import com.aventstack.extentreports.model.Author;
 import com.aventstack.extentreports.model.Category;
@@ -136,7 +132,7 @@ abstract class ExtentObservable
 	private ReportStatusStats stats = new ReportStatusStats(strategy);
 	
 	/**
-	 * A Set of status tests are marked with
+	 * A unique collection of statuses tests are marked with
 	 * 
 	 * <p>
 	 * Consider a report having 10 tests:

--- a/src/main/java/com/aventstack/extentreports/ExtentTest.java
+++ b/src/main/java/com/aventstack/extentreports/ExtentTest.java
@@ -1190,21 +1190,7 @@ public class ExtentTest
      * @return {@link Status}
      */
     public Status getStatus() {
-    	/*
-    	 * Flushing the report here seems counter intuitive. However,
-    	 * the status of the report is not updated till we get a
-    	 * call to read something the current status of the report.
-    	 * This allows us to delay the work which we would have done
-    	 * on every update to the status.
-    	 * @viren: Think of a better design to store and update the status
-    	 * 
-    	 * For the time being we will resort to flush here as it still
-    	 * avoid the additional work we used to do with every log addition
-    	 * and it also minimizes the risk of getting Concurrent modification
-    	 * error.
-    	 * Done as part of: pull request #75	
-    	 */
-    	extent.flush();
+    	extent.generateRecentStatus();
         return getModel().getStatus();
     }
 
@@ -1229,5 +1215,4 @@ public class ExtentTest
     void setUseManualConfiguration(Boolean b) {
         getModel().setUseManualConfiguration(b);
     }
-    
 }

--- a/src/main/java/com/aventstack/extentreports/ReportAggregates.java
+++ b/src/main/java/com/aventstack/extentreports/ReportAggregates.java
@@ -3,7 +3,6 @@ package com.aventstack.extentreports;
 import java.util.Collection;
 import java.util.Date;
 import java.util.List;
-import java.util.Set;
 
 import com.aventstack.extentreports.model.Author;
 import com.aventstack.extentreports.model.Category;

--- a/src/main/java/com/aventstack/extentreports/ReportService.java
+++ b/src/main/java/com/aventstack/extentreports/ReportService.java
@@ -8,6 +8,7 @@ import com.aventstack.extentreports.reporter.AbstractReporter;
  */
 public interface ReportService {
     
-	void attachReporter(ExtentReporter... reporter);	
+	void attachReporter(ExtentReporter... reporter);
+	void generateRecentStatus();
 	
 }

--- a/src/test/java/com/aventstack/extentreports/api/BddWithStepStatusHierarchyTest.java
+++ b/src/test/java/com/aventstack/extentreports/api/BddWithStepStatusHierarchyTest.java
@@ -112,7 +112,8 @@ public class BddWithStepStatusHierarchyTest extends Base {
         ExtentTest when = scenario.createNode(new GherkinKeyword("When"), "When").pass("pass");
         ExtentTest then = scenario.createNode(new GherkinKeyword("Then"), "Then").skip("skip");
         ExtentTest but = scenario.createNode(new GherkinKeyword("But"), "But").skip("skip");
-
+        extent.flush();
+        
         Assert.assertEquals(given.getStatus(), Status.PASS);
         Assert.assertEquals(and.getStatus(), Status.PASS);
         Assert.assertEquals(when.getStatus(), Status.PASS);
@@ -131,6 +132,7 @@ public class BddWithStepStatusHierarchyTest extends Base {
         ExtentTest when = scenario.createNode(When.class, "When").pass("pass");
         ExtentTest then = scenario.createNode(Then.class, "Then").skip("skip");
         ExtentTest but = scenario.createNode(But.class, "But").skip("skip");
+        extent.flush();
 
         Assert.assertEquals(given.getStatus(), Status.PASS);
         Assert.assertEquals(and.getStatus(), Status.PASS);
@@ -150,7 +152,8 @@ public class BddWithStepStatusHierarchyTest extends Base {
         ExtentTest when = scenario.createNode(new GherkinKeyword("When"), "When").skip("skip");
         ExtentTest then = scenario.createNode(new GherkinKeyword("Then"), "Then").warning("warning");
         ExtentTest but = scenario.createNode(new GherkinKeyword("But"), "But").warning("warning");
-
+        extent.flush();
+        
         Assert.assertEquals(given.getStatus(), Status.SKIP);
         Assert.assertEquals(and.getStatus(), Status.SKIP);
         Assert.assertEquals(when.getStatus(), Status.SKIP);
@@ -169,7 +172,8 @@ public class BddWithStepStatusHierarchyTest extends Base {
         ExtentTest when = scenario.createNode(When.class, "When").skip("skip");
         ExtentTest then = scenario.createNode(Then.class, "Then").warning("warning");
         ExtentTest but = scenario.createNode(But.class, "But").warning("warning");
-
+        extent.flush();
+        
         Assert.assertEquals(given.getStatus(), Status.SKIP);
         Assert.assertEquals(and.getStatus(), Status.SKIP);
         Assert.assertEquals(when.getStatus(), Status.SKIP);
@@ -188,7 +192,8 @@ public class BddWithStepStatusHierarchyTest extends Base {
         ExtentTest when = scenario.createNode(new GherkinKeyword("When"), "When").warning("warning");
         ExtentTest then = scenario.createNode(new GherkinKeyword("Then"), "Then").error("error");
         ExtentTest but = scenario.createNode(new GherkinKeyword("But"), "But").error("error");
-
+        extent.flush();
+        
         Assert.assertEquals(given.getStatus(), Status.WARNING);
         Assert.assertEquals(and.getStatus(), Status.WARNING);
         Assert.assertEquals(when.getStatus(), Status.WARNING);
@@ -207,7 +212,8 @@ public class BddWithStepStatusHierarchyTest extends Base {
         ExtentTest when = scenario.createNode(When.class, "When").warning("warning");
         ExtentTest then = scenario.createNode(Then.class, "Then").error("error");
         ExtentTest but = scenario.createNode(But.class, "But").error("error");
-
+        extent.flush();
+        
         Assert.assertEquals(given.getStatus(), Status.WARNING);
         Assert.assertEquals(and.getStatus(), Status.WARNING);
         Assert.assertEquals(when.getStatus(), Status.WARNING);
@@ -226,7 +232,8 @@ public class BddWithStepStatusHierarchyTest extends Base {
         ExtentTest when = scenario.createNode(new GherkinKeyword("When"), "When").error("error");
         ExtentTest then = scenario.createNode(new GherkinKeyword("Then"), "Then").fail("fail");
         ExtentTest but = scenario.createNode(new GherkinKeyword("But"), "But").fail("fail");
-
+        extent.flush();
+        
         Assert.assertEquals(given.getStatus(), Status.ERROR);
         Assert.assertEquals(and.getStatus(), Status.ERROR);
         Assert.assertEquals(when.getStatus(), Status.ERROR);
@@ -245,7 +252,8 @@ public class BddWithStepStatusHierarchyTest extends Base {
         ExtentTest when = scenario.createNode(When.class, "When").error("error");
         ExtentTest then = scenario.createNode(Then.class, "Then").fail("fail");
         ExtentTest but = scenario.createNode(But.class, "But").fail("fail");
-
+        extent.flush();
+        
         Assert.assertEquals(given.getStatus(), Status.ERROR);
         Assert.assertEquals(and.getStatus(), Status.ERROR);
         Assert.assertEquals(when.getStatus(), Status.ERROR);
@@ -264,7 +272,8 @@ public class BddWithStepStatusHierarchyTest extends Base {
         ExtentTest when = scenario.createNode(new GherkinKeyword("When"), "When").fail("fail");
         ExtentTest then = scenario.createNode(new GherkinKeyword("Then"), "Then").fatal("fatal");
         ExtentTest but = scenario.createNode(new GherkinKeyword("But"), "But").fatal("fatal");
-
+        extent.flush();
+        
         Assert.assertEquals(given.getStatus(), Status.FAIL);
         Assert.assertEquals(and.getStatus(), Status.FAIL);
         Assert.assertEquals(when.getStatus(), Status.FAIL);
@@ -283,7 +292,8 @@ public class BddWithStepStatusHierarchyTest extends Base {
         ExtentTest when = scenario.createNode(When.class, "When").fail("fail");
         ExtentTest then = scenario.createNode(Then.class, "Then").fatal("fatal");
         ExtentTest but = scenario.createNode(But.class, "But").fatal("fatal");
-
+        extent.flush();
+        
         Assert.assertEquals(given.getStatus(), Status.FAIL);
         Assert.assertEquals(and.getStatus(), Status.FAIL);
         Assert.assertEquals(when.getStatus(), Status.FAIL);

--- a/src/test/java/com/aventstack/extentreports/api/NodeSingleLogsStatusTest.java
+++ b/src/test/java/com/aventstack/extentreports/api/NodeSingleLogsStatusTest.java
@@ -26,6 +26,7 @@ public class NodeSingleLogsStatusTest extends Base {
     public void verifyIfTestHasStatusSkip(Method method) {
         ExtentTest test = extent.createTest(method.getName());
         ExtentTest node = test.createNode("Child").skip("skip");
+        extent.flush();
 
         Assert.assertEquals(node.getModel().getLevel(), 1);
         Assert.assertEquals(node.getModel().getLogContext().size(), 1);
@@ -37,6 +38,7 @@ public class NodeSingleLogsStatusTest extends Base {
     public void verifyIfTestHasStatusWarning(Method method) {
         ExtentTest test = extent.createTest(method.getName());
         ExtentTest node = test.createNode("Child").warning("warning");
+        extent.flush();
 
         Assert.assertEquals(node.getModel().getLevel(), 1);
         Assert.assertEquals(node.getModel().getLogContext().size(), 1);
@@ -48,7 +50,8 @@ public class NodeSingleLogsStatusTest extends Base {
     public void verifyIfTestHasStatusError(Method method) {
         ExtentTest test = extent.createTest(method.getName());
         ExtentTest node = test.createNode("Child").error("error");
-
+        extent.flush();
+        
         Assert.assertEquals(node.getModel().getLevel(), 1);
         Assert.assertEquals(node.getModel().getLogContext().size(), 1);
         Assert.assertEquals(node.getStatus(), Status.ERROR);
@@ -59,7 +62,8 @@ public class NodeSingleLogsStatusTest extends Base {
     public void verifyIfTestHasStatusFail(Method method) {
         ExtentTest test = extent.createTest(method.getName());
         ExtentTest node = test.createNode("Child").fail("fail");
-
+        extent.flush();
+        
         Assert.assertEquals(node.getModel().getLevel(), 1);
         Assert.assertEquals(node.getModel().getLogContext().size(), 1);
         Assert.assertEquals(node.getStatus(), Status.FAIL);
@@ -70,7 +74,8 @@ public class NodeSingleLogsStatusTest extends Base {
     public void verifyIfTestHasStatusFatal(Method method) {
         ExtentTest test = extent.createTest(method.getName());
         ExtentTest node = test.createNode("Child").fatal("fatal");
-
+        extent.flush();
+        
         Assert.assertEquals(node.getModel().getLevel(), 1);
         Assert.assertEquals(node.getModel().getLogContext().size(), 1);
         Assert.assertEquals(node.getStatus(), Status.FATAL);

--- a/src/test/java/com/aventstack/extentreports/api/NodesStatusHierarchyTest.java
+++ b/src/test/java/com/aventstack/extentreports/api/NodesStatusHierarchyTest.java
@@ -11,165 +11,175 @@ import com.aventstack.extentreports.Status;
 
 public class NodesStatusHierarchyTest extends Base {
 
-    @Test
-    public void verifyPassHasHigherPriorityThanInfoLevelsShallow(Method method) {
-        ExtentTest parent = extent.createTest(method.getName());
-        ExtentTest child = parent.createNode("Child");
-        child.info("info");
-        child.pass("pass");
-        
-        Assert.assertEquals(child.getModel().getLevel(), 1);
-        Assert.assertEquals(parent.getStatus(), Status.PASS);
-        Assert.assertEquals(child.getStatus(), Status.PASS);
-    }
-    
-    @Test
-    public void verifyPassHasHigherPriorityThanInfoLevelsDeep(Method method) {
-        ExtentTest parent = extent.createTest(method.getName());
-        ExtentTest child = parent.createNode("Child");
-        ExtentTest grandchild = child.createNode("GrandChild");
-        grandchild.info("info");
-        grandchild.pass("pass");
-        
-        Assert.assertEquals(child.getModel().getLevel(), 1);
-        Assert.assertEquals(grandchild.getModel().getLevel(), 2);
-        Assert.assertEquals(parent.getStatus(), Status.PASS);
-        Assert.assertEquals(child.getStatus(), Status.PASS);
-        Assert.assertEquals(grandchild.getStatus(), Status.PASS);
-    }
-    
-    @Test
-    public void verifySkipHasHigherPriorityThanPassLevelsShallow(Method method) {
-        ExtentTest parent = extent.createTest(method.getName());
-        ExtentTest child = parent.createNode("Child");
-        child.pass("pass");
-        child.skip("skip");
-        
-        Assert.assertEquals(child.getModel().getLevel(), 1);
-        Assert.assertEquals(parent.getStatus(), Status.SKIP);
-        Assert.assertEquals(child.getStatus(), Status.SKIP);
-    }
-    
-    @Test
-    public void verifySkipHasHigherPriorityThanPassLevelsDeep(Method method) {
-        ExtentTest parent = extent.createTest(method.getName());
-        ExtentTest child = parent.createNode("Child");
-        ExtentTest grandchild = child.createNode("GrandChild");
-        grandchild.pass("pass");
-        grandchild.skip("skip");
-        
-        Assert.assertEquals(child.getModel().getLevel(), 1);
-        Assert.assertEquals(grandchild.getModel().getLevel(), 2);
-        Assert.assertEquals(parent.getStatus(), Status.SKIP);
-        Assert.assertEquals(child.getStatus(), Status.SKIP);
-        Assert.assertEquals(grandchild.getStatus(), Status.SKIP);
-    }
-    
-    @Test
-    public void verifyWarningHasHigherPriorityThanSkipLevelsShallow(Method method) {
-        ExtentTest parent = extent.createTest(method.getName());
-        ExtentTest child = parent.createNode("Child");
-        child.skip("skip");
-        child.warning("warning");
-        
-        Assert.assertEquals(child.getModel().getLevel(), 1);
-        Assert.assertEquals(parent.getStatus(), Status.WARNING);
-        Assert.assertEquals(child.getStatus(), Status.WARNING);
-    }
-    
-    @Test
-    public void verifyWarningHasHigherPriorityThanSkipLevelsDeep(Method method) {
-        ExtentTest parent = extent.createTest(method.getName());
-        ExtentTest child = parent.createNode("Child");
-        ExtentTest grandchild = child.createNode("GrandChild");
-        grandchild.skip("skip");
-        grandchild.warning("warning");
-        
-        Assert.assertEquals(child.getModel().getLevel(), 1);
-        Assert.assertEquals(grandchild.getModel().getLevel(), 2);
-        Assert.assertEquals(parent.getStatus(), Status.WARNING);
-        Assert.assertEquals(child.getStatus(), Status.WARNING);
-        Assert.assertEquals(grandchild.getStatus(), Status.WARNING);
-    }
-    
-    @Test
-    public void verifyErrorHasHigherPriorityThanWarningLevelsShallow(Method method) {
-        ExtentTest parent = extent.createTest(method.getName());
-        ExtentTest child = parent.createNode("Child");
-        child.warning("warning");
-        child.error("error");
-        
-        Assert.assertEquals(child.getModel().getLevel(), 1);
-        Assert.assertEquals(parent.getStatus(), Status.ERROR);
-        Assert.assertEquals(child.getStatus(), Status.ERROR);
-    }
-    
-    @Test
-    public void verifyErrorHasHigherPriorityThanWarningLevelsDeep(Method method) {
-        ExtentTest parent = extent.createTest(method.getName());
-        ExtentTest child = parent.createNode("Child");
-        ExtentTest grandchild = child.createNode("GrandChild");
-        grandchild.warning("warning");
-        grandchild.error("error");
-        
-        Assert.assertEquals(child.getModel().getLevel(), 1);
-        Assert.assertEquals(grandchild.getModel().getLevel(), 2);
-        Assert.assertEquals(parent.getStatus(), Status.ERROR);
-        Assert.assertEquals(child.getStatus(), Status.ERROR);
-        Assert.assertEquals(grandchild.getStatus(), Status.ERROR);
-    }
-    
-    @Test
-    public void verifFailHasHigherPriorityThanErrorLevelsShallow(Method method) {
-        ExtentTest parent = extent.createTest(method.getName());
-        ExtentTest child = parent.createNode("Child");
-        child.error("error");
-        child.fail("fail");
-        
-        Assert.assertEquals(child.getModel().getLevel(), 1);
-        Assert.assertEquals(parent.getStatus(), Status.FAIL);
-        Assert.assertEquals(child.getStatus(), Status.FAIL);
-    }
-    
-    @Test
-    public void verifFailHasHigherPriorityThanErrorLevelsDeep(Method method) {
-        ExtentTest parent = extent.createTest(method.getName());
-        ExtentTest child = parent.createNode("Child");
-        ExtentTest grandchild = child.createNode("GrandChild");
-        grandchild.error("error");
-        grandchild.fail("fail");
-        
-        Assert.assertEquals(child.getModel().getLevel(), 1);
-        Assert.assertEquals(grandchild.getModel().getLevel(), 2);
-        Assert.assertEquals(parent.getStatus(), Status.FAIL);
-        Assert.assertEquals(child.getStatus(), Status.FAIL);
-        Assert.assertEquals(grandchild.getStatus(), Status.FAIL);
-    }
-    
-    @Test
-    public void verifFatalHasHigherPriorityThanFailLevelsShallow(Method method) {
-        ExtentTest parent = extent.createTest(method.getName());
-        ExtentTest child = parent.createNode("Child");
-        child.fail("fail");
-        child.fatal("fatal");
-        
-        Assert.assertEquals(child.getModel().getLevel(), 1);
-        Assert.assertEquals(parent.getStatus(), Status.FATAL);
-        Assert.assertEquals(child.getStatus(), Status.FATAL);
-    }
-    
-    @Test
-    public void verifFatalHasHigherPriorityThanFailLevelsDeep(Method method) {
-        ExtentTest parent = extent.createTest(method.getName());
-        ExtentTest child = parent.createNode("Child");
-        ExtentTest grandchild = child.createNode("GrandChild");
-        grandchild.fail("fail");
-        grandchild.fatal("fatal");
-        
-        Assert.assertEquals(child.getModel().getLevel(), 1);
-        Assert.assertEquals(grandchild.getModel().getLevel(), 2);
-        Assert.assertEquals(parent.getStatus(), Status.FATAL);
-        Assert.assertEquals(child.getStatus(), Status.FATAL);
-        Assert.assertEquals(grandchild.getStatus(), Status.FATAL);
-    }
+	@Test
+	public void verifyPassHasHigherPriorityThanInfoLevelsShallow(Method method) {
+		ExtentTest parent = extent.createTest(method.getName());
+		ExtentTest child = parent.createNode("Child");
+		child.info("info");
+		child.pass("pass");
+
+		Assert.assertEquals(child.getModel().getLevel(), 1);
+		Assert.assertEquals(parent.getStatus(), Status.PASS);
+		Assert.assertEquals(child.getStatus(), Status.PASS);
+	}
+
+	@Test
+	public void verifyPassHasHigherPriorityThanInfoLevelsDeep(Method method) {
+		ExtentTest parent = extent.createTest(method.getName());
+		ExtentTest child = parent.createNode("Child");
+		ExtentTest grandchild = child.createNode("GrandChild");
+		grandchild.info("info");
+		grandchild.pass("pass");
+
+		Assert.assertEquals(child.getModel().getLevel(), 1);
+		Assert.assertEquals(grandchild.getModel().getLevel(), 2);
+		Assert.assertEquals(parent.getStatus(), Status.PASS);
+		Assert.assertEquals(child.getStatus(), Status.PASS);
+		Assert.assertEquals(grandchild.getStatus(), Status.PASS);
+	}
+
+	@Test
+	public void verifySkipHasHigherPriorityThanPassLevelsShallow(Method method) {
+		ExtentTest parent = extent.createTest(method.getName());
+		ExtentTest child = parent.createNode("Child");
+		child.pass("pass");
+		child.skip("skip");
+		extent.flush();
+
+		Assert.assertEquals(child.getModel().getLevel(), 1);
+		Assert.assertEquals(parent.getStatus(), Status.SKIP);
+		Assert.assertEquals(child.getStatus(), Status.SKIP);
+	}
+
+	@Test
+	public void verifySkipHasHigherPriorityThanPassLevelsDeep(Method method) {
+		ExtentTest parent = extent.createTest(method.getName());
+		ExtentTest child = parent.createNode("Child");
+		ExtentTest grandchild = child.createNode("GrandChild");
+		grandchild.pass("pass");
+		grandchild.skip("skip");
+		extent.flush();
+
+		Assert.assertEquals(child.getModel().getLevel(), 1);
+		Assert.assertEquals(grandchild.getModel().getLevel(), 2);
+		Assert.assertEquals(parent.getStatus(), Status.SKIP);
+		Assert.assertEquals(child.getStatus(), Status.SKIP);
+		Assert.assertEquals(grandchild.getStatus(), Status.SKIP);
+	}
+
+	@Test
+	public void verifyWarningHasHigherPriorityThanSkipLevelsShallow(Method method) {
+		ExtentTest parent = extent.createTest(method.getName());
+		ExtentTest child = parent.createNode("Child");
+		child.skip("skip");
+		child.warning("warning");
+		extent.flush();
+
+		Assert.assertEquals(child.getModel().getLevel(), 1);
+		Assert.assertEquals(parent.getStatus(), Status.WARNING);
+		Assert.assertEquals(child.getStatus(), Status.WARNING);
+	}
+
+	@Test
+	public void verifyWarningHasHigherPriorityThanSkipLevelsDeep(Method method) {
+		ExtentTest parent = extent.createTest(method.getName());
+		ExtentTest child = parent.createNode("Child");
+		ExtentTest grandchild = child.createNode("GrandChild");
+		grandchild.skip("skip");
+		grandchild.warning("warning");
+		extent.flush();
+
+		Assert.assertEquals(child.getModel().getLevel(), 1);
+		Assert.assertEquals(grandchild.getModel().getLevel(), 2);
+		Assert.assertEquals(parent.getStatus(), Status.WARNING);
+		Assert.assertEquals(child.getStatus(), Status.WARNING);
+		Assert.assertEquals(grandchild.getStatus(), Status.WARNING);
+	}
+
+	@Test
+	public void verifyErrorHasHigherPriorityThanWarningLevelsShallow(Method method) {
+		ExtentTest parent = extent.createTest(method.getName());
+		ExtentTest child = parent.createNode("Child");
+		child.warning("warning");
+		child.error("error");
+		extent.flush();
+
+		Assert.assertEquals(child.getModel().getLevel(), 1);
+		Assert.assertEquals(parent.getStatus(), Status.ERROR);
+		Assert.assertEquals(child.getStatus(), Status.ERROR);
+	}
+
+	@Test
+	public void verifyErrorHasHigherPriorityThanWarningLevelsDeep(Method method) {
+		ExtentTest parent = extent.createTest(method.getName());
+		ExtentTest child = parent.createNode("Child");
+		ExtentTest grandchild = child.createNode("GrandChild");
+		grandchild.warning("warning");
+		grandchild.error("error");
+		extent.flush();
+
+		Assert.assertEquals(child.getModel().getLevel(), 1);
+		Assert.assertEquals(grandchild.getModel().getLevel(), 2);
+		Assert.assertEquals(parent.getStatus(), Status.ERROR);
+		Assert.assertEquals(child.getStatus(), Status.ERROR);
+		Assert.assertEquals(grandchild.getStatus(), Status.ERROR);
+	}
+
+	@Test
+	public void verifFailHasHigherPriorityThanErrorLevelsShallow(Method method) {
+		ExtentTest parent = extent.createTest(method.getName());
+		ExtentTest child = parent.createNode("Child");
+		child.error("error");
+		child.fail("fail");
+		extent.flush();
+
+		Assert.assertEquals(child.getModel().getLevel(), 1);
+		Assert.assertEquals(parent.getStatus(), Status.FAIL);
+		Assert.assertEquals(child.getStatus(), Status.FAIL);
+	}
+
+	@Test
+	public void verifFailHasHigherPriorityThanErrorLevelsDeep(Method method) {
+		ExtentTest parent = extent.createTest(method.getName());
+		ExtentTest child = parent.createNode("Child");
+		ExtentTest grandchild = child.createNode("GrandChild");
+		grandchild.error("error");
+		grandchild.fail("fail");
+		extent.flush();
+
+		Assert.assertEquals(child.getModel().getLevel(), 1);
+		Assert.assertEquals(grandchild.getModel().getLevel(), 2);
+		Assert.assertEquals(parent.getStatus(), Status.FAIL);
+		Assert.assertEquals(child.getStatus(), Status.FAIL);
+		Assert.assertEquals(grandchild.getStatus(), Status.FAIL);
+	}
+
+	@Test
+	public void verifFatalHasHigherPriorityThanFailLevelsShallow(Method method) {
+		ExtentTest parent = extent.createTest(method.getName());
+		ExtentTest child = parent.createNode("Child");
+		child.fail("fail");
+		child.fatal("fatal");
+		extent.flush();
+
+		Assert.assertEquals(child.getModel().getLevel(), 1);
+		Assert.assertEquals(parent.getStatus(), Status.FATAL);
+		Assert.assertEquals(child.getStatus(), Status.FATAL);
+	}
+
+	@Test
+	public void verifFatalHasHigherPriorityThanFailLevelsDeep(Method method) {
+		ExtentTest parent = extent.createTest(method.getName());
+		ExtentTest child = parent.createNode("Child");
+		ExtentTest grandchild = child.createNode("GrandChild");
+		grandchild.fail("fail");
+		grandchild.fatal("fatal");
+		extent.flush();
+
+		Assert.assertEquals(child.getModel().getLevel(), 1);
+		Assert.assertEquals(grandchild.getModel().getLevel(), 2);
+		Assert.assertEquals(parent.getStatus(), Status.FATAL);
+		Assert.assertEquals(child.getStatus(), Status.FATAL);
+		Assert.assertEquals(grandchild.getStatus(), Status.FATAL);
+	}
 }

--- a/src/test/java/com/aventstack/extentreports/api/TestStartEndDateTimeTest.java
+++ b/src/test/java/com/aventstack/extentreports/api/TestStartEndDateTimeTest.java
@@ -51,6 +51,7 @@ public class TestStartEndDateTimeTest extends Base {
         ExtentTest node = test.createNode(method.getName());
         Thread.sleep(wait);
         node.pass("pass");
+        extent.flush();
         
         Assert.assertTrue(test.getModel().getEndTime().getTime() >= (init.getTime() + wait));
     }


### PR DESCRIPTION
**Issue:** When we call ExtentTest.addLog we recalculate all the report analytics(collectRunInfo method). This is a costly process and it is required only when we flush reports.

**_Fix:_** I have moved the collectRunInfo to be called only when we do flush on the report. That is when in an ideal design we should be collecting all the information from tests. However, the exiting code seems to be there for a reason. @anshooarora : Please take a look at this PR as it changes the ExtentReports at a fundamental level.