### PR TITLE
Simplifying recursion and changing name of public method

### DIFF
--- a/src/main/java/com/aventstack/extentreports/ExtentObservable.java
+++ b/src/main/java/com/aventstack/extentreports/ExtentObservable.java
@@ -277,7 +277,7 @@ abstract class ExtentObservable
     		return;
 
     	list.forEach(x -> statusSet.add(x.getStatus()));   	
-    	list.forEach(x -> refreshStatusList(x.getNodeContext().getAll()));
+    	list.forEach(x -> refreshStatusList(x.getChildrenNodes().getAll()));
     }
     
     /**
@@ -451,7 +451,7 @@ abstract class ExtentObservable
                 	.forEach(x -> exceptionContextBuilder.setExceptionContext(x, test));
             }
             if (test.hasChildren()) {
-                for (Test node : test.getNodeContext().getAll()) {
+                for (Test node : test.getChildrenNodes().getAll()) {
                     copyNodeAttributeAndRunTimeInfoToAttributeContexts(node);
                     node.setUseManualConfiguration(getAllowManualConfig());
                 }
@@ -504,7 +504,7 @@ abstract class ExtentObservable
             	.forEach(x -> exceptionContextBuilder.setExceptionContext(x, node));
         }
         if (node.hasChildren()) {
-            node.getNodeContext().getAll()
+            node.getChildrenNodes().getAll()
             	.forEach(this::copyNodeAttributeAndRunTimeInfoToAttributeContexts);
         }
     }

--- a/src/main/java/com/aventstack/extentreports/ExtentTest.java
+++ b/src/main/java/com/aventstack/extentreports/ExtentTest.java
@@ -277,7 +277,7 @@ public class ExtentTest
     private void applyCommonNodeSettings(ExtentTest extentTest) {
         extentTest.getModel().setLevel(test.getLevel() + 1);
         extentTest.getModel().setParent(getModel());
-        test.getNodeContext().add(extentTest.getModel());
+        test.addChildNode(extentTest.getModel());
     }
     
     private void addNodeToReport(ExtentTest extentNode) {

--- a/src/main/java/com/aventstack/extentreports/ReportStatusStats.java
+++ b/src/main/java/com/aventstack/extentreports/ReportStatusStats.java
@@ -192,7 +192,7 @@ public class ReportStatusStats {
     }
     
     private void addTestForStatusStatsUpdate(Test test) {
-        if (test.isBehaviorDrivenType() || (test.hasChildren() && test.getNodeContext().get(0).isBehaviorDrivenType())) {
+        if (test.isBehaviorDrivenType() || (test.hasChildren() && test.getChildrenNodes().get(0).isBehaviorDrivenType())) {
             updateGroupCountsBDD(test);
             return;
         }
@@ -214,11 +214,11 @@ public class ReportStatusStats {
         incrementItemCountByStatus(ItemLevel.PARENT, test.getStatus());
         
         if (test.hasChildren()) {
-            test.getNodeContext().getAll().forEach(x -> {
+            test.getChildrenNodes().getAll().forEach(x -> {
                 incrementItemCountByStatus(ItemLevel.CHILD, x.getStatus());
 
                 if (x.hasChildren())
-                    x.getNodeContext().getAll().forEach(n -> incrementItemCountByStatus(ItemLevel.GRANDCHILD, n.getStatus()));
+                    x.getChildrenNodes().getAll().forEach(n -> incrementItemCountByStatus(ItemLevel.GRANDCHILD, n.getStatus()));
             });
         }
     }
@@ -227,16 +227,16 @@ public class ReportStatusStats {
         incrementItemCountByStatus(ItemLevel.PARENT, test.getStatus());
         
         if (test.hasChildren()) {
-            test.getNodeContext().getAll().forEach(x -> {
+            test.getChildrenNodes().getAll().forEach(x -> {
                 if (x.getBehaviorDrivenType() == Scenario.class)
                     incrementItemCountByStatus(ItemLevel.CHILD, x.getStatus());
 
                 if (x.hasChildren()) {
-                    x.getNodeContext().getAll().forEach(n -> {
+                    x.getChildrenNodes().getAll().forEach(n -> {
                         if (n.getBehaviorDrivenType() == Scenario.class) {
                             incrementItemCountByStatus(ItemLevel.CHILD, n.getStatus());
                             
-                            n.getNodeContext().getAll().forEach(z -> incrementItemCountByStatus(ItemLevel.GRANDCHILD, z.getStatus()));
+                            n.getChildrenNodes().getAll().forEach(z -> incrementItemCountByStatus(ItemLevel.GRANDCHILD, z.getStatus()));
                         }
                         else {
                             incrementItemCountByStatus(ItemLevel.GRANDCHILD, n.getStatus());
@@ -256,7 +256,7 @@ public class ReportStatusStats {
     }
     
     private void updateGroupCountsTestStrategyChildren(Test test) {
-    	test.getNodeContext().getAll().forEach(x -> {
+    	test.getChildrenNodes().getAll().forEach(x -> {
     		if (!x.hasChildren()) {
     			incrementItemCountByStatus(ItemLevel.CHILD, x.getStatus());
     		} else {

--- a/src/main/java/com/aventstack/extentreports/TestRemover.java
+++ b/src/main/java/com/aventstack/extentreports/TestRemover.java
@@ -50,7 +50,7 @@ class TestRemover {
         	if (removed) {
         		return;
         	}
-        	findAndRemoveTest(t.getNodeContext().getAll(), test);
+        	findAndRemoveTest(t.getChildrenNodes().getAll(), test);
         }
     }
     

--- a/src/main/java/com/aventstack/extentreports/model/Test.java
+++ b/src/main/java/com/aventstack/extentreports/model/Test.java
@@ -290,6 +290,9 @@ public class Test
     }
 
     private synchronized void updateTestStatusRecursive(Test test) {
+    	// Update this test first, based on the logs
+        test.getLogContext().getAll().forEach(x -> updateStatus(x.getStatus()));
+    	
     	
     	// Recursively update the status of all the children in the tree
         if (test.hasChildren()) {
@@ -298,7 +301,7 @@ public class Test
         
         // At this point the subtree should be updated. Now we have to update the status
         // of current node.
-        test.getLogContext().getAll().forEach(x -> updateStatus(x.getStatus()));
+        test.getChildrenNodes().getAll().forEach(x -> updateStatus(x.getStatus()));
     }
     
     private void endChildrenRecursive(Test test) {

--- a/src/main/java/com/aventstack/extentreports/reporter/ExtentKlovReporter.java
+++ b/src/main/java/com/aventstack/extentreports/reporter/ExtentKlovReporter.java
@@ -496,8 +496,8 @@ public class ExtentKlovReporter extends AbstractReporter {
 				.append("level", test.getLevel()).append("name", test.getName())
 				.append("status", test.getStatus().toString()).append("description", test.getDescription())
 				.append("startTime", test.getStartTime()).append("endTime", test.getEndTime())
-				.append("bdd", test.isBehaviorDrivenType()).append("leaf", test.getNodeContext().size() == 0)
-				.append("childNodesLength", test.getNodeContext().size());
+				.append("bdd", test.isBehaviorDrivenType()).append("leaf", test.getChildrenNodes().size() == 0)
+				.append("childNodesLength", test.getChildrenNodes().size());
 
 		if (test.isBehaviorDrivenType()) {
 			doc.append("bddType", test.getBehaviorDrivenType().getSimpleName());
@@ -520,7 +520,7 @@ public class ExtentKlovReporter extends AbstractReporter {
 	}
 
 	private void updateTestChildrenCount(Test test) {
-		Document doc = new Document("childNodesLength", test.getNodeContext().size());
+		Document doc = new Document("childNodesLength", test.getChildrenNodes().size());
 		testCollection.updateOne(new Document("_id", test.getObjectId()), new Document("$set", doc));
 	}
 
@@ -596,8 +596,8 @@ public class ExtentKlovReporter extends AbstractReporter {
 
 	private void endTestRecursive(Test test) {
 		Document doc = new Document("status", test.getStatus().toString()).append("endTime", test.getEndTime())
-				.append("duration", test.getRunDurationMillis()).append("leaf", test.getNodeContext().size() == 0)
-				.append("childNodesLength", test.getNodeContext().size()).append("categorized", test.hasCategory())
+				.append("duration", test.getRunDurationMillis()).append("leaf", test.getChildrenNodes().size() == 0)
+				.append("childNodesLength", test.getChildrenNodes().size()).append("categorized", test.hasCategory())
 				.append("description", test.getDescription());
 
 		testCollection.updateOne(new Document("_id", test.getObjectId()), new Document("$set", doc));

--- a/src/test/java/com/aventstack/extentreports/api/TestInitializeNullValuesTest.java
+++ b/src/test/java/com/aventstack/extentreports/api/TestInitializeNullValuesTest.java
@@ -87,7 +87,7 @@ public class TestInitializeNullValuesTest extends Base {
         ExtentTest test = extent.createTest(method.getName()).fail("fail");
         ExtentTest node = test.createNode(null);
         
-        Assert.assertEquals(test.getModel().getNodeContext().size(), 0);
+        Assert.assertEquals(test.getModel().getChildrenNodes().size(), 0);
         Assert.assertNull(node);
     }
     
@@ -96,7 +96,7 @@ public class TestInitializeNullValuesTest extends Base {
         ExtentTest test = extent.createTest(method.getName()).fail("fail");
         ExtentTest node = test.createNode("");
         
-        Assert.assertEquals(test.getModel().getNodeContext().size(), 0);
+        Assert.assertEquals(test.getModel().getChildrenNodes().size(), 0);
         Assert.assertNull(node);
     }
     

--- a/src/test/java/com/aventstack/extentreports/api/TestStartEndDateTimeTest.java
+++ b/src/test/java/com/aventstack/extentreports/api/TestStartEndDateTimeTest.java
@@ -116,7 +116,7 @@ public class TestStartEndDateTimeTest extends Base {
         ExtentTest node = test.createNode(method.getName());
         Thread.sleep(wait);
         node.pass("pass");
-        test.getModel().setStartTime(test.getModel().getNodeContext().getLast().getEndTime());
+        test.getModel().setStartTime(test.getModel().getChildrenNodes().getLast().getEndTime());
         
         Assert.assertTrue(test.getModel().getStartTime().getTime() >= (init.getTime() + wait));
     }
@@ -145,7 +145,7 @@ public class TestStartEndDateTimeTest extends Base {
         ExtentTest node = test.createNode(method.getName());
         Thread.sleep(wait);
         node.pass("pass");
-        test.getModel().setEndTime(test.getModel().getNodeContext().getLast().getEndTime());
+        test.getModel().setEndTime(test.getModel().getChildrenNodes().getLast().getEndTime());
         
         Assert.assertTrue(test.getModel().getEndTime().getTime() >= (init.getTime() + wait));
     }

--- a/src/test/java/com/aventstack/extentreports/model/TestModelTest.java
+++ b/src/test/java/com/aventstack/extentreports/model/TestModelTest.java
@@ -38,21 +38,21 @@ public class TestModelTest extends Base {
     @Test
     public void testNodeContextIsEmpty(Method method) {
         ExtentTest t = extent.createTest(method.getName());
-        Assert.assertTrue(t.getModel().getNodeContext().isEmpty());
+        Assert.assertTrue(t.getModel().getChildrenNodes().isEmpty());
     }
     
     @Test
     public void testNodeContextIsNotEmpty(Method method) {
         ExtentTest t = extent.createTest(method.getName());
         t.createNode(method.getName());
-        Assert.assertFalse(t.getModel().getNodeContext().isEmpty());
+        Assert.assertFalse(t.getModel().getChildrenNodes().isEmpty());
     }
     
     @Test
     public void testNodeContextFirstNotNull(Method method) {
         ExtentTest t = extent.createTest(method.getName());
         t.createNode(method.getName());
-        Assert.assertTrue(t.getModel().getNodeContext().getFirst()!=null);
+        Assert.assertTrue(t.getModel().getChildrenNodes().getFirst()!=null);
     }
     
     @Test
@@ -60,7 +60,7 @@ public class TestModelTest extends Base {
         ExtentTest t = extent.createTest(method.getName());
         String name = method.getName() + "x";
         t.createNode(name);
-        Assert.assertTrue(t.getModel().getNodeContext().getFirst().getName().equals(name));
+        Assert.assertTrue(t.getModel().getChildrenNodes().getFirst().getName().equals(name));
     }
     
     @Test
@@ -68,7 +68,7 @@ public class TestModelTest extends Base {
         ExtentTest t = extent.createTest(method.getName());
         String name = method.getName() + "x";
         t.createNode(name);
-        Assert.assertTrue(t.getModel().getNodeContext().getLast().getName().equals(name));
+        Assert.assertTrue(t.getModel().getChildrenNodes().getLast().getName().equals(name));
     }
     
     @Test
@@ -78,8 +78,8 @@ public class TestModelTest extends Base {
         t.createNode(name1);
         String name2 = method.getName() + "x2";
         t.createNode(name2);
-        Assert.assertTrue(t.getModel().getNodeContext().getFirst().getName().equals(name1));
-        Assert.assertTrue(t.getModel().getNodeContext().getLast().getName().equals(name2));
+        Assert.assertTrue(t.getModel().getChildrenNodes().getFirst().getName().equals(name1));
+        Assert.assertTrue(t.getModel().getChildrenNodes().getLast().getName().equals(name2));
     }
     
     @Test
@@ -89,8 +89,8 @@ public class TestModelTest extends Base {
         t.createNode(name1);
         String name2 = method.getName() + "x2";
         t.createNode(name2);
-        Assert.assertTrue(t.getModel().getNodeContext().get(0).getName().equals(name1));
-        Assert.assertTrue(t.getModel().getNodeContext().get(1).getName().equals(name2));
+        Assert.assertTrue(t.getModel().getChildrenNodes().get(0).getName().equals(name1));
+        Assert.assertTrue(t.getModel().getChildrenNodes().get(1).getName().equals(name2));
     }
     
     @Test


### PR DESCRIPTION
Fix details:
1. Simplifying the recursion of Test.updateTestStatusRecursive. Now we are 1 less recursion.
2. Changed the name of the method Test.getNodeContext to Test.getChildrenNodes. This name makes more sense as we are dealing with a tree-like structure. NodeContext is not intuitive.

Note: Second change will cause a breaking change. The name of a public API method has changed. However, the impact is low.
Also, change 1 is important as it reduces the recursion and hopefully will give a significant perf improvement.