### PR TITLE
Fix encoding problem when generating extent reports

### DIFF
--- a/src/main/java/com/aventstack/extentreports/io/BufferedWriterWriter.java
+++ b/src/main/java/com/aventstack/extentreports/io/BufferedWriterWriter.java
@@ -2,7 +2,9 @@ package com.aventstack.extentreports.io;
 
 import java.io.BufferedWriter;
 import java.io.File;
-import java.io.FileWriter;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -20,10 +22,12 @@ public class BufferedWriterWriter {
     private BufferedWriterWriter() {
     }
 
-    public synchronized void write(final File f, String text) {
-        try (BufferedWriter writer = new BufferedWriter(new FileWriter(f))) {
+    public synchronized void write(final File f, String text, String encoding) {
+        try (BufferedWriter writer = new BufferedWriter(
+                new OutputStreamWriter(
+                        new FileOutputStream(f), encoding))) {
             writer.write(text);
-        } catch (Exception e) {
+        } catch (IOException e) {
             logger.log(Level.SEVERE, f.getPath(), e);
         }
     }

--- a/src/main/java/com/aventstack/extentreports/reporter/AbstractFileReporter.java
+++ b/src/main/java/com/aventstack/extentreports/reporter/AbstractFileReporter.java
@@ -69,8 +69,9 @@ public abstract class AbstractFileReporter extends AbstractFilterableReporter {
         }
     }
 
-    protected void processTemplate(Template template, File outputFile) throws TemplateException, IOException {
+    protected void processTemplate(Template template, File outputFile, String encoding) throws TemplateException, IOException {
         FreemarkerTemplate freemarkerTemplate = new FreemarkerTemplate(getFreemarkerConfig());
+        freemarkerConfig.setDefaultEncoding(encoding);
         freemarkerTemplate.writeTemplate(template, templateModel, outputFile);
     }
 

--- a/src/main/java/com/aventstack/extentreports/reporter/ExtentSparkReporter.java
+++ b/src/main/java/com/aventstack/extentreports/reporter/ExtentSparkReporter.java
@@ -146,7 +146,7 @@ public class ExtentSparkReporter extends AbstractFileReporter
             createFreemarkerConfig(TEMPLATE_LOCATION, ENCODING);
             final String filePath = getFileNameAsExt(FILE_NAME, new String[]{".html", ".htm"});
             final Template template = getFreemarkerConfig().getTemplate(SPA_TEMPLATE_NAME);
-            processTemplate(template, new File(filePath));
+            processTemplate(template, new File(filePath), conf.getEncoding());
             return;
         } catch (IOException | TemplateException e) {
             disposable.dispose();

--- a/src/main/java/com/aventstack/extentreports/templating/FreemarkerTemplate.java
+++ b/src/main/java/com/aventstack/extentreports/templating/FreemarkerTemplate.java
@@ -43,7 +43,7 @@ public class FreemarkerTemplate {
     public void writeTemplate(Template template, Map<String, Object> templateMap, File outputFile)
             throws TemplateException, IOException {
         String source = getSource(template, templateMap);
-        BufferedWriterWriter.getInstance().write(outputFile, source);
+        BufferedWriterWriter.getInstance().write(outputFile, source, freemarkerConfig.getDefaultEncoding());
     }
 
     private String processTemplate(Template template, Map<String, Object> templateMap)


### PR DESCRIPTION
When write the extent report In BufferedWriterWriter.java the ‘write’ method use the default system encoding instead of what the user is set in reporter.config().setEncodint() or to use the default encoding set to be “UTF-8” in FileReporterConfig.java.