### PR TITLE
Adds the test description to the card body

### DIFF
--- a/src/main/resources/com/aventstack/extentreports/templates/spark/macros/recurse_nodes.ftl
+++ b/src/main/resources/com/aventstack/extentreports/templates/spark/macros/recurse_nodes.ftl
@@ -22,6 +22,7 @@
         <#if node.hasLog()>
         <div class="<#if node.status.toLower()!='fail'>collapse</#if>">
           <div class="card-body">
+            <#if node.description?has_content><p>${node.description}</p></#if>
             <@log test=node />
             <@media node.media />
           </div>


### PR DESCRIPTION
We use the `@description` annotation to add more meaning to a test.
This PR also adds it to the reporting 🥳  on a node level.

```java
@Test(testName = "tests login button", description = "This test clicks the login button. ")
public void testLoginButton() {
    // test here
}
```