### PR TITLE
Fix Ids in FreeMarker templates for values greater than 999

### DIFF
--- a/src/main/resources/com/aventstack/extentreports/markup/codeblock.json.ftl
+++ b/src/main/resources/com/aventstack/extentreports/markup/codeblock.json.ftl
@@ -1,3 +1,4 @@
+<#setting number_format="0">
 <#list code as c>
  <div class='json-tree' id='code-block-json-${index}'></div>
  <script>

--- a/src/main/resources/com/aventstack/extentreports/templates/spark/macros/attr-common.ftl
+++ b/src/main/resources/com/aventstack/extentreports/templates/spark/macros/attr-common.ftl
@@ -43,7 +43,7 @@
                   <td><span class="badge log ${test.status.toLower()}-bg">${test.status?string}</span></td>
                   <td>${test.startTime?string[("HH:mm:ss a")]}</td>
                   <td>
-                    <a href="#" class="linked" test-id='${test.getAncestor().getId()}' id='${test.getId()}'>${test.name}</a>
+                    <a href="#" class="linked" test-id='${test.getAncestor().getId()?string["0"]}' id='${test.getId()?string["0"]}'>${test.name}</a>
                     <#if test.parent??>
                     <div class="">
                       <span class="badge badge-default">${test.getFullName()}</span>

--- a/src/main/resources/com/aventstack/extentreports/templates/spark/macros/recurse_nodes.ftl
+++ b/src/main/resources/com/aventstack/extentreports/templates/spark/macros/recurse_nodes.ftl
@@ -13,7 +13,7 @@
             </ul>
           </div>
           <div class="card-title">
-            <a class="node <#if !node.hasChildren() && node.status=='FAIL'>collapsed</#if>" id="${node.getId()}"><span>${node.name}</span></a>
+            <a class="node <#if !node.hasChildren() && node.status=='FAIL'>collapsed</#if>" id="${node.getId()?string["0"]}"><span>${node.name}</span></a>
             <div class="node-attr">
                 <#if node.hasAttributes()><@attributes test=node /></#if>
             </div>

--- a/src/main/resources/com/aventstack/extentreports/templates/spark/partials/bdd-content.ftl
+++ b/src/main/resources/com/aventstack/extentreports/templates/spark/partials/bdd-content.ftl
@@ -15,7 +15,7 @@
   <div class="card">
     <div class="card-header" role="tab">
       <div class="card-title">
-        <div class="node" id="${node.getId()}"><span class="badge log ${node.status.toLower()}-bg mr-2">${node.status?string}</span>${node.name}</div>
+        <div class="node" id="${node.getId()?string["0"]}"><span class="badge log ${node.status.toLower()}-bg mr-2">${node.status?string}</span>${node.name}</div>
         <#if TestService.testHasScreenCapture(node, true)>
           <div class="status-avatar float-right mr-4">
             <i class="fa fa-paperclip"></i>
@@ -30,7 +30,7 @@
             <div class="card-body l1">
               <div class="card-header">
                 <div class="card-title outline-child">
-                  <div class="node" id="${child.getId()}"><span class="badge log ${child.status.toLower()}-bg mr-2">${child.status?string}</span>${child.name}</div>
+                  <div class="node" id="${child.getId()?string["0"]}"><span class="badge log ${child.status.toLower()}-bg mr-2">${child.status?string}</span>${child.name}</div>
                   <#if TestService.testHasScreenCapture(child, true)>
                     <div class="status-avatar float-right">
                       <i class="fa fa-paperclip"></i>

--- a/src/main/resources/com/aventstack/extentreports/templates/spark/partials/test.ftl
+++ b/src/main/resources/com/aventstack/extentreports/templates/spark/partials/test.ftl
@@ -49,7 +49,7 @@
     <div class="test-list-wrapper scrollable">
       <ul class="test-list-item">
         <#list report.testList as test>
-        <li class="test-item"  status="${test.status.toLower()}" test-id="${test.getId()}"
+        <li class="test-item"  status="${test.status.toLower()}" test-id="${test.getId()?string["0"]}"
           author="<#list test.authorSet as x>${x.name}<#if x_has_next> </#if></#list>"
           tag="<#list test.categorySet as x>${x.name}<#if x_has_next> </#if></#list>"
           device="<#list test.deviceSet as x>${x.name}<#if x_has_next> </#if></#list>">
@@ -69,7 +69,7 @@
                   <span class='badge badge-success'>${test.startTime?string("MM.dd.yyyy")} ${test.startTime?time?string}</span>
                   <span class='badge badge-danger'>${test.endTime?string("MM.dd.yyyy")} ${test.endTime?time?string}</span>
                   <span class='badge badge-default'>${test.timeTakenPretty()}</span>
-                  &middot; <span class='uri-anchor badge badge-default'>#test-id=${test.getId()}</span>
+                  &middot; <span class='uri-anchor badge badge-default'>#test-id=${test.getId()?string["0"]}</span>
                   <span title='Skip to the next failed step' class='badge badge-danger pointer float-right ne ml-1'><i class="fa fa-fast-forward"></i></span>
                   <span title='Collapse all nodes' class='badge badge-default pointer float-right ct ml-1'><i class="fa fa-compress"></i></span>
                   <span title='Expand all nodes' class='badge badge-default pointer float-right et'><i class="fa fa-expand"></i></span>


### PR DESCRIPTION
Depending on locale setting, current conversion of ids can result in point or comma separated numbers.
This breaks things like json code blocks because of invalid JS function naming (e.g. jsonTreeCreate1.000())

Behaviour can be reproduced by the follwing code:
```
for (int i = 0; i < 1000; i++)
  MarkupHelper.createCodeBlock("{ 'key': 'value' }", CodeLanguage.JSON).getMarkup();
System.out.println(MarkupHelper.createCodeBlock("{ 'key': 'value' }", CodeLanguage.JSON).getMarkup());
```

Fixed by setting formatting options in affected .ftl files